### PR TITLE
Move dotenv dependency to a separate `dev` install mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "google_analytics_data_json"
-version = "0.0.2.2"
+version = "0.0.2.3"
 authors = [
   { name="Daniel Jerrehian", email="danieljerrehian@gmail.com" },
 ]
@@ -31,11 +31,15 @@ dependencies = [
   'protobuf==3.20.1',
   'pyasn1==0.4.8',
   'pyasn1-modules==0.2.8',
-  'python-dotenv~=0.20.0',
   'requests>=2.28.1',
   'rsa~=4.8',
   'six~=1.16.0',
   'google-api-python-client~=2.86.0'
+]
+
+[project.optional-dependencies]
+dev = [
+  'python-dotenv<1'
 ]
 
 [project.urls]


### PR DESCRIPTION
We encountered an issue where the `dotenv` dependency has a pinned version, which was conflicting with another dependency in our codebase. 

This change fixes it by moving `dotenv` to the optional dependencies part, and makes is so that dotenv is only installed with `pip install google-analytics-data-json[dev]`. Consider unpinning the version of dotenv entirely, as I believe it has high backwards-compatibility. 

It also bumps the version number. It would be much-appreciated if you could do a full release (git tag, and pypi release) of this version.